### PR TITLE
Vectorize small-offset overlapping copies on AArch64 with NEON tbl

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -222,9 +222,61 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */
+#if defined(ZSTD_ARCH_ARM_NEON)
+        /* The source and destination overlap with period `diff` (1 <= diff < 16).
+         * Build one 16-byte register holding the repeating pattern, then store 16
+         * bytes per iteration (vs 8 with COPY8), advancing the pattern with a single
+         * table lookup. There is no load inside the loop.
+         *   init[diff][j] = j % diff        : build the pattern from a 16-byte load
+         *   adv[diff][j]  = (16 + j) % diff : shift the pattern forward by 16 bytes */
+        static const uint8_t init[16][16] = {
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+            { 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0},
+            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0},
+            { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0},
+        };
+        static const uint8_t adv[16][16] = {
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+            { 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1},
+            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
+            { 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1},
+            { 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1},
+            { 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4},
+            { 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1},
+            { 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+            { 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2, 3, 4, 5},
+            { 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1, 2, 3},
+            { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 1},
+        };
+        uint8x16_t pattern = vqtbl1q_u8(vld1q_u8((const uint8_t*)ip), vld1q_u8(init[diff]));
+        uint8x16_t const advance = vld1q_u8(adv[diff]);
+        do {
+            vst1q_u8((uint8_t*)op, pattern);
+            pattern = vqtbl1q_u8(pattern, advance);
+            op += 16;
+        } while (op < oend);
+#else
         do {
             COPY8(op, ip);
         } while (op < oend);
+#endif
     } else {
         assert(diff >= WILDCOPY_VECLEN || diff <= -WILDCOPY_VECLEN);
         /* Separate out the first COPY16() call because the copy length is


### PR DESCRIPTION
Used by ClickHouse: https://github.com/ClickHouse/ClickHouse/pull/108049

## Vectorize small-offset overlapping copies on AArch64 with NEON `tbl`

For small match offsets (overlap period < 16 bytes), `ZSTD_wildcopy` falls back to an 8-byte-per-iteration `COPY8` loop. On AArch64 this loop dominates decompression of integer and low-cardinality data, whose matches frequently have offsets of 4 or 8 bytes (e.g. runs of repeated fixed-width values).

This builds the repeating pattern once in a NEON register and stores **16 bytes per iteration**, advancing the pattern with a single `vqtbl1q_u8` table lookup and **no load inside the loop**:

- `init[diff][j] = j % diff` builds the period-`diff` pattern from a 16-byte load;
- `adv[diff][j] = (16 + j) % diff` shifts the pattern forward by 16 bytes each iteration, which composes correctly because `pattern[k] = src[k % diff]`.

The scalar `COPY8` path is kept unchanged for non-NEON targets.

### Results

On Graviton 4 (Neoverse-V2), ZSTD level 1 decompression of ClickBench `hits` columns (decompression throughput, best of several runs):

| column | type | baseline MB/s | patched MB/s | speedup |
|---|---|---|---|---|
| `UserID` | Int64 | 2624 | 6053 | **2.30x** |
| `AdvEngineID` | Int16 | 5990 | 8712 | **1.46x** |
| `ClientIP` | Int32 | 1857 | 2607 | **1.42x** |
| `RegionID` | Int32 | 2468 | 3127 | **1.27x** |
| `URL` / `Title` / `Referer` | String | — | — | ~1.00x (unchanged) |
| `WatchID` | Int64 (incompressible) | — | — | ~1.00x (unchanged) |

### Correctness

Round-trip decompression is byte-exact against the original input for all tested columns at block sizes from 4 KB to 1 MB, and clean under AddressSanitizer and UndefinedBehaviorSanitizer. The 16-byte stores overrun the output by at most 15 bytes, well within the existing `WILDCOPY_OVERLENGTH` (32) slack already required by the non-overlapping path.
