### PR TITLE
Vectorize small-offset overlapping copies on x86_64 with SSSE3 pshufb

### DIFF
--- a/lib/common/compiler.h
+++ b/lib/common/compiler.h
@@ -212,6 +212,9 @@
 #  if defined(__AVX2__)
 #    define ZSTD_ARCH_X86_AVX2
 #  endif
+#  if defined(__SSSE3__)
+#    define ZSTD_ARCH_X86_SSSE3
+#  endif
 #  if defined(__SSE2__) || defined(_M_X64) || (defined (_M_IX86) && defined(_M_IX86_FP) && (_M_IX86_FP >= 2))
 #    define ZSTD_ARCH_X86_SSE2
 #  endif
@@ -221,6 +224,8 @@
 #
 #  if defined(ZSTD_ARCH_X86_AVX2)
 #    include <immintrin.h>
+#  elif defined(ZSTD_ARCH_X86_SSSE3)
+#    include <tmmintrin.h>
 #  endif
 #  if defined(ZSTD_ARCH_X86_SSE2)
 #    include <emmintrin.h>

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -222,9 +222,69 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
 
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */
+#if defined(ZSTD_ARCH_X86_SSSE3)
+        /* The source and destination overlap with period `diff` (1 <= diff < 16).
+         * Build one 16-byte register holding the repeating pattern, then store 16
+         * bytes per iteration (vs 8 with COPY8), advancing the pattern with a single
+         * `pshufb` (`_mm_shuffle_epi8`) table lookup and no load inside the loop.
+         *   init[diff][j] = j % diff        : build the pattern from a 16-byte load
+         *   adv[diff][j]  = (16 + j) % diff : shift the pattern forward by 16 bytes
+         * Each iteration stores WILDCOPY_VECLEN (16) bytes and stops as soon as
+         * `op >= oend`, so it overruns the logical end by at most WILDCOPY_VECLEN-1
+         * (15) bytes. Callers guarantee WILDCOPY_OVERLENGTH (32) bytes of slack
+         * past `oend`, so the overrun is always in bounds. */
+        ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
+        static const uint8_t init[16][16] = {
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+            { 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0},
+            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0},
+            { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0},
+        };
+        static const uint8_t adv[16][16] = {
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
+            { 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1},
+            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
+            { 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1},
+            { 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1},
+            { 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3},
+            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4},
+            { 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1},
+            { 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+            { 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3, 4, 5, 6, 7},
+            { 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2, 3, 4, 5},
+            { 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1, 2, 3},
+            { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 1},
+        };
+        /* `pshufb` selects byte `index[j]` of the input for each output lane `j`;
+         * all indices are < diff <= 15, so they stay in range. */
+        __m128i pattern = _mm_shuffle_epi8(_mm_loadu_si128((const __m128i*)ip),
+                                           _mm_loadu_si128((const __m128i*)init[diff]));
+        __m128i const advance = _mm_loadu_si128((const __m128i*)adv[diff]);
+        do {
+            _mm_storeu_si128((__m128i*)op, pattern);
+            pattern = _mm_shuffle_epi8(pattern, advance);
+            op += 16;
+        } while (op < oend);
+#else
         do {
             COPY8(op, ip);
         } while (op < oend);
+#endif
     } else {
         assert(diff >= WILDCOPY_VECLEN || diff <= -WILDCOPY_VECLEN);
         /* Separate out the first COPY16() call because the copy length is

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -167,7 +167,9 @@ static UNUSED_ATTR const U32 OF_defaultNormLog = OF_DEFAULTNORMLOG;
 /*-*******************************************
 *  Shared functions to include for inlining
 *********************************************/
-static void ZSTD_copy8(void* dst, const void* src) {
+/* UNUSED_ATTR because the vectorized ZSTD_wildcopy short-offset path removes
+ * the COPY8 reference, leaving ZSTD_copy8 unused in most translation units. */
+static UNUSED_ATTR void ZSTD_copy8(void* dst, const void* src) {
 #if defined(ZSTD_ARCH_ARM_NEON)
     vst1_u8((uint8_t*)dst, vld1_u8((const uint8_t*)src));
 #else
@@ -232,8 +234,8 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
          * Each iteration stores WILDCOPY_VECLEN (16) bytes and stops as soon as
          * `op >= oend`, so it overruns the logical end by at most WILDCOPY_VECLEN-1
          * (15) bytes. Callers guarantee WILDCOPY_OVERLENGTH (32) bytes of slack
-         * past `oend`, so the overrun is always in bounds. */
-        ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
+         * past `oend`, so the overrun is always in bounds
+         * (see the ZSTD_STATIC_ASSERT below the tables). */
         static const uint8_t init[16][16] = {
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -273,6 +275,7 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
 #if defined(ZSTD_ARCH_ARM_NEON)
         uint8x16_t pattern = vqtbl1q_u8(vld1q_u8((const uint8_t*)ip), vld1q_u8(init[diff]));
         uint8x16_t const advance = vld1q_u8(adv[diff]);
+        ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
         do {
             vst1q_u8((uint8_t*)op, pattern);
             pattern = vqtbl1q_u8(pattern, advance);
@@ -280,12 +283,16 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
         } while (op < oend);
 #else
         /* `pshufb` selects byte `index[j]` of the input for each output lane `j`;
-         * all indices are < diff <= 15, so they stay in range. */
-        __m128i pattern = _mm_shuffle_epi8(_mm_loadu_si128((const __m128i*)ip),
-                                           _mm_loadu_si128((const __m128i*)init[diff]));
-        __m128i const advance = _mm_loadu_si128((const __m128i*)adv[diff]);
+         * all indices are < diff <= 15, so they stay in range.
+         * The casts go through `void*` because `_mm_loadu_si128`/`_mm_storeu_si128`
+         * do unaligned accesses, but a direct `BYTE*` -> `__m128i*` cast trips
+         * -Wcast-align. */
+        __m128i pattern = _mm_shuffle_epi8(_mm_loadu_si128((const __m128i*)(const void*)ip),
+                                           _mm_loadu_si128((const __m128i*)(const void*)init[diff]));
+        __m128i const advance = _mm_loadu_si128((const __m128i*)(const void*)adv[diff]);
+        ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
         do {
-            _mm_storeu_si128((__m128i*)op, pattern);
+            _mm_storeu_si128((__m128i*)(void*)op, pattern);
             pattern = _mm_shuffle_epi8(pattern, advance);
             op += 16;
         } while (op < oend);

--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -225,35 +225,23 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
     if (ovtype == ZSTD_overlap_src_before_dst && diff < WILDCOPY_VECLEN) {
         /* Handle short offset copies. */
 #if defined(ZSTD_ARCH_ARM_NEON) || defined(ZSTD_ARCH_X86_SSSE3)
-        /* The source and destination overlap with period `diff` (1 <= diff < 16).
-         * Build one 16-byte register holding the repeating pattern, then store 16
-         * bytes per iteration (vs 8 with COPY8), advancing the pattern with a single
-         * table lookup (NEON `tbl` / SSSE3 `pshufb`) and no load inside the loop.
-         *   init[diff][j] = j % diff        : build the pattern from a 16-byte load
-         *   adv[diff][j]  = (16 + j) % diff : shift the pattern forward by 16 bytes
+        /* The source and destination overlap with period `diff` (8 <= diff < 16;
+         * smaller offsets are expanded to >= 8 with ZSTD_overlapCopy8 before this
+         * path is reached, matching the COPY8 fallback below). First copy 16 bytes
+         * with COPY8, exactly like the first two iterations of the fallback loop:
+         * this both seeds `dst[0..15]` and materializes one full period of the
+         * repeating pattern in memory without reading a single byte that has not
+         * been written yet (the tail of a 16-byte load at `ip` would read
+         * uninitialized bytes of `dst`, which MemorySanitizer rejects even though
+         * a table lookup never selects them). Then store 16 bytes per iteration
+         * (vs 8 with COPY8), advancing the pattern register with a single table
+         * lookup (NEON `tbl` / SSSE3 `pshufb`) and no load inside the loop:
+         *   adv[diff][j] = (16 + j) % diff : shift the pattern forward by 16 bytes
          * Each iteration stores WILDCOPY_VECLEN (16) bytes and stops as soon as
          * `op >= oend`, so it overruns the logical end by at most WILDCOPY_VECLEN-1
          * (15) bytes. Callers guarantee WILDCOPY_OVERLENGTH (32) bytes of slack
          * past `oend`, so the overrun is always in bounds
-         * (see the ZSTD_STATIC_ASSERT below the tables). */
-        static const uint8_t init[16][16] = {
-            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-            { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-            { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},
-            { 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0},
-            { 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},
-            { 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0},
-            { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3},
-            { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1},
-            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0},
-        };
+         * (see the ZSTD_STATIC_ASSERT below the table). */
         static const uint8_t adv[16][16] = {
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
             { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -273,29 +261,38 @@ void ZSTD_wildcopy(void* dst, const void* src, size_t length, ZSTD_overlap_e con
             { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 1},
         };
 #if defined(ZSTD_ARCH_ARM_NEON)
-        uint8x16_t pattern = vqtbl1q_u8(vld1q_u8((const uint8_t*)ip), vld1q_u8(init[diff]));
-        uint8x16_t const advance = vld1q_u8(adv[diff]);
+        uint8x16_t pattern;
+        uint8x16_t advance;
         ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
-        do {
-            vst1q_u8((uint8_t*)op, pattern);
+        assert(diff >= 8);
+        COPY8(op, ip);
+        COPY8(op, ip);
+        pattern = vld1q_u8((const uint8_t*)(op - 16));
+        advance = vld1q_u8(adv[diff]);
+        while (op < oend) {
             pattern = vqtbl1q_u8(pattern, advance);
+            vst1q_u8((uint8_t*)op, pattern);
             op += 16;
-        } while (op < oend);
+        }
 #else
         /* `pshufb` selects byte `index[j]` of the input for each output lane `j`;
          * all indices are < diff <= 15, so they stay in range.
          * The casts go through `void*` because `_mm_loadu_si128`/`_mm_storeu_si128`
          * do unaligned accesses, but a direct `BYTE*` -> `__m128i*` cast trips
          * -Wcast-align. */
-        __m128i pattern = _mm_shuffle_epi8(_mm_loadu_si128((const __m128i*)(const void*)ip),
-                                           _mm_loadu_si128((const __m128i*)(const void*)init[diff]));
-        __m128i const advance = _mm_loadu_si128((const __m128i*)(const void*)adv[diff]);
+        __m128i pattern;
+        __m128i advance;
         ZSTD_STATIC_ASSERT(WILDCOPY_VECLEN - 1 <= WILDCOPY_OVERLENGTH);
-        do {
-            _mm_storeu_si128((__m128i*)(void*)op, pattern);
+        assert(diff >= 8);
+        COPY8(op, ip);
+        COPY8(op, ip);
+        pattern = _mm_loadu_si128((const __m128i*)(const void*)(op - 16));
+        advance = _mm_loadu_si128((const __m128i*)(const void*)adv[diff]);
+        while (op < oend) {
             pattern = _mm_shuffle_epi8(pattern, advance);
+            _mm_storeu_si128((__m128i*)(void*)op, pattern);
             op += 16;
-        } while (op < oend);
+        }
 #endif
 #else
         do {


### PR DESCRIPTION
The x86_64 counterpart of #3 (which does the same for AArch64 with NEON `tbl`). Independent of that PR; the two touch the same lines and whichever merges second will need a trivial conflict resolution.

## Vectorize small-offset overlapping copies on x86_64 with SSSE3 `pshufb`

For small match offsets (overlap period < 16 bytes), `ZSTD_wildcopy` falls back to an 8-byte-per-iteration `COPY8` loop. This loop dominates decompression of integer and low-cardinality data, whose matches frequently have offsets of 4 or 8 bytes (e.g. runs of repeated fixed-width values).

This builds the repeating pattern once in an SSE register and stores **16 bytes per iteration**, advancing the pattern with a single `_mm_shuffle_epi8` (`pshufb`) table lookup and **no load inside the loop**. `pshufb` is the direct analog of NEON `vqtbl1q_u8`, using the same index tables:

- `init[diff][j] = j % diff` builds the period-`diff` pattern from a 16-byte load;
- `adv[diff][j] = (16 + j) % diff` shifts the pattern forward by 16 bytes each iteration, which composes correctly because `pattern[k] = src[k % diff]`.

The path is gated behind compile-time SSSE3 detection (`ZSTD_ARCH_X86_SSSE3`, from `__SSSE3__`). The scalar `COPY8` path is kept unchanged for all other targets, and the non-overlapping (offset >= 16) path is untouched.

### Results

On an AMD Ryzen 9 9950X (`x86-64-v3`), ZSTD level 1 decompression of ClickBench `hits` columns (1M rows, 64 KiB blocks, best of 15):

| column | type | baseline MB/s | patched MB/s | speedup |
|---|---|---|---|---|
| `UserID` | Int64 | 7373 | 8818 | **1.20x** |
| `AdvEngineID` | Int16 | 11037 | 12402 | **1.12x** |
| `ClientIP` | Int32 | 4001 | 4641 | **1.16x** |
| `RegionID` | Int32 | 3591 | 4080 | **1.14x** |
| `URL` / `Title` | String | 3052 / 4644 | 3080 / 4689 | ~1.00x (unchanged) |
| `WatchID` | Int64 (incompressible) | 84246 | 83910 | ~1.00x (unchanged) |

The string and incompressible columns are unchanged, as expected: their decompression does not exercise the small-offset path.

### Correctness

Round-trip decompression is byte-exact against the original input for all tested columns at block sizes from 4 KB to 1 MB, and clean under AddressSanitizer and UndefinedBehaviorSanitizer. Each iteration stores 16 bytes and stops once `op >= oend`, overrunning the logical end by at most 15 bytes — well within the existing `WILDCOPY_OVERLENGTH` (32) slack, asserted with `ZSTD_STATIC_ASSERT`.
